### PR TITLE
When iterating over database keys with a for statement, only one key could be retrieved

### DIFF
--- a/sqldbm_tests.py
+++ b/sqldbm_tests.py
@@ -79,6 +79,15 @@ class SqliteDbmTestCase(unittest.TestCase):
             self.db[f"rec{i}"] = random.randbytes(5)
         self.assertEqual(count, len(self.db))
 
+    def test_iter(self):
+        """Verify iteration over database"""
+        self.db['a'] = b'hello world'
+        self.db['b'] = b'something else'
+        key_set = set()
+        for key in self.db:
+            key_set.add(key)
+        self.assertEqual(set(['a', 'b']), key_set)
+
 
 class SqliteDbmUseCaseTestCase(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
This pull request is to solve a database iteration problem I've encountered.
The PR contains the code modifications and the added test case.

---

When I run the following scripts:

```python
import sqldbm

db = sqldbm.open('test.db', sqldbm.Mode.OPEN_CREATE_NEW)

db['a'] = b'a'
db['b'] = b'B'
db['C'] = b'C'

db.close()
```

```python
import sqldbm

db = sqldbm.open('test.db', sqldbm.Mode.OPEN_READ_ONLY)

for k in db:
    v = db[k]
    print("k = %s, v = %s" % (repr(k), repr(v)))

db.close()
```

I noticed that the latter script printed the following:

```
k = 'C', v = b'C'
```
